### PR TITLE
Fix encoding issues in PDF header

### DIFF
--- a/inc/common.class.php
+++ b/inc/common.class.php
@@ -306,8 +306,14 @@ abstract class PluginPdfCommon extends CommonGLPI {
          if (Session::isMultiEntitiesMode() && $this->obj->isEntityAssign()) {
             $entity = ' ('.Dropdown::getDropdownName('glpi_entities', $this->obj->getEntityID()).')';
          }
-         $this->pdf->setHeader(sprintf(__('%1$s - %2$s'), $this->obj->getTypeName(),
-                                       sprintf(__('%1$s %2$s'), $name, $entity)));
+         $header = Toolbox::unclean_cross_side_scripting_deep(
+            sprintf(
+               __('%1$s - %2$s'),
+               $this->obj->getTypeName(),
+               sprintf(__('%1$s %2$s'), $name, $entity)
+            )
+         );
+         $this->pdf->setHeader($header);
 
          return true;
       }


### PR DESCRIPTION
When the main item contains `<` or `>` char in its name, or when it is located in a sub entity, `&gt;` or `&lt;` chars are displayed in the PDF header. This is due to the fact that PDF title and header data is handled as plain text by TCPDF.

Using `Toolbox::unclean_cross_side_scripting_deep()` will decode `<` and `>` chars and will prevent this issue.