### PR TITLE
fix: formatting solutions

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -67,8 +67,7 @@ class PluginPdfITILSolution extends PluginPdfCommon {
             } else {
                $title = __('Solution');
             }
-            $sol = Toolbox::stripTags(Glpi\Toolbox\Sanitizer::unsanitize(html_entity_decode($row['content'],
-                                                                         ENT_QUOTES, "UTF-8")));
+            $sol = Glpi\Toolbox\Sanitizer::unsanitize(html_entity_decode($row['content'], ENT_QUOTES, "UTF-8"));
 
             if ($row['status'] == 3) {
                $text = __('Soluce approved on ', 'pdf');


### PR DESCRIPTION
Solution formatting was not applied in the PDF

Example:
![image](https://github.com/yllen/pdf/assets/8530352/25f29b95-967c-441d-a308-eaf3db131b37)

Before:
![image](https://github.com/yllen/pdf/assets/8530352/b8ddfcb5-2cd1-4360-8893-85b8283289ff)

After:
![image](https://github.com/yllen/pdf/assets/8530352/14ddc729-cae1-4e5d-934f-e391e7ae5ea2)
