### PR TITLE
Fix itilsolution picture visibility

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -67,8 +67,18 @@ class PluginPdfITILSolution extends PluginPdfCommon {
             } else {
                $title = __('Solution');
             }
-            $sol = Toolbox::stripTags(Glpi\Toolbox\Sanitizer::unsanitize(html_entity_decode($row['content'],
-                                                                         ENT_QUOTES, "UTF-8")));
+            $sol = Glpi\Toolbox\Sanitizer::unsanitize(Html::entity_decode_deep($row['content']));
+            $sol = preg_replace('#data:image/[^;]+;base64,#', '@', $sol);
+
+            preg_match_all('/<img [^>]*src=[\'"]([^\'"]*docid=([0-9]*))[^>]*>/', $sol, $res, PREG_SET_ORDER);
+
+            foreach ($res as $img) {
+               $docimg = new Document();
+               $docimg->getFromDB($img[2]);
+
+               $path = '<img src="file://'.GLPI_DOC_DIR.'/'.$docimg->fields['filepath'].'"/>';
+               $sol = str_replace($img[0], $path, $sol);
+            }
 
             if ($row['status'] == 3) {
                $text = __('Soluce approved on ', 'pdf');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33378

The images contained in a solution description did not appear. In addition, the IF checking whether there had been an approval was true all the time, displaying "By" all the time.

**Before**
![image](https://github.com/yllen/pdf/assets/107540223/08fac971-dcc7-4dbc-a356-2e3bf6d2214e)

**After**
![image](https://github.com/yllen/pdf/assets/107540223/9bc82fec-2cca-45d3-a135-bf3ef99b69c7)